### PR TITLE
fix(acl) fix regression bug due to ACL support on non-secured cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Option                                  Description
 --dry-run                               OPTION : Execute command in Dry-Run   
                                           mode                                
 --entity-type <String>                  OPTION : entity on which to execute   
-                                          command [topics|users]              
+                                          command [topics|acls]
 --execute                               COMMAND: Align cluster resources with 
                                           the specified specifications        
 --file <File>                           The cluster specification to used for 

--- a/src/main/java/com/zenika/kafka/specs/EntityType.java
+++ b/src/main/java/com/zenika/kafka/specs/EntityType.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.zenika.kafka.specs;
+
+public enum EntityType {
+
+    TOPICS, ACLS;
+
+    public static EntityType from(final String type) {
+        return EntityType.valueOf(type.toUpperCase());
+    }
+
+}

--- a/src/main/java/com/zenika/kafka/specs/KafkaSpecsRunner.java
+++ b/src/main/java/com/zenika/kafka/specs/KafkaSpecsRunner.java
@@ -56,12 +56,12 @@ public class KafkaSpecsRunner {
 
                 Collection<OperationResult> results = new LinkedList<>();
 
-                if (options.entityTypes().contains("topics")) {
+                if (options.entityTypes().contains(EntityType.TOPICS)) {
                     ExecuteTopicCommand command = new ExecuteTopicCommand(client);
                     results.addAll(command.execute(options));
                 }
 
-                if (options.entityTypes().contains("acls")) {
+                if (options.entityTypes().contains(EntityType.ACLS)) {
                     AclRulesBuilder builder = AclRulesBuilder.combines(
                             new LiteralAclRulesBuilder(),
                             new TopicMatchingAclRulesBuilder(client));

--- a/src/main/java/com/zenika/kafka/specs/KafkaSpecsRunnerOptions.java
+++ b/src/main/java/com/zenika/kafka/specs/KafkaSpecsRunnerOptions.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -177,8 +178,10 @@ public class KafkaSpecsRunnerOptions {
         }
     }
 
-    public Collection<String> entityTypes() {
-        return (options.has(entityTypes)) ? entityTypes.values(options) : Collections.emptyList();
+    public Collection<EntityType> entityTypes() {
+        return (options.has(entityTypes)) ?
+                entityTypes.values(options).stream().map(EntityType::from).collect(Collectors.toList()) :
+                Collections.emptyList();
     }
 
     public boolean hasSingleAction() {


### PR DESCRIPTION
The describe command can be used with parameter entity-type to only
describe a specific entity (i.e topics or acls)